### PR TITLE
Use dominant-baseline if alignment-baseline is missing (#80) & ctx fix

### DIFF
--- a/src/applyparseattributes.ts
+++ b/src/applyparseattributes.ts
@@ -125,7 +125,8 @@ export function parseAttributes(context: Context, svgNode: SvgNode, node?: Eleme
 
   const alignmentBaseline =
     getAttribute(domNode, context.styleSheets, 'vertical-align') ||
-    getAttribute(domNode, context.styleSheets, 'alignment-baseline')
+    getAttribute(domNode, context.styleSheets, 'alignment-baseline') ||
+    getAttribute(domNode, context.styleSheets, 'dominant-baseline')
   if (alignmentBaseline) {
     const matchArr = alignmentBaseline.match(
       /(baseline|text-bottom|alphabetic|ideographic|middle|central|mathematical|text-top|bottom|center|top|hanging)/

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -16,7 +16,7 @@ import { GraphicsNode } from './graphicsnode'
 import { Rect } from '../utils/geometry'
 import { Matrix } from 'jspdf'
 import { SvgNode } from './svgnode'
-import { parseAttributes } from '../applyparseattributes'
+import { parseAttributes, applyContext } from '../applyparseattributes'
 
 interface TrimInfo {
   prevText: string
@@ -153,6 +153,7 @@ export class TextNode extends GraphicsNode {
       if (visibility === 'visible') {
         const alignmentBaseline = context.attributeState.alignmentBaseline
         const textRenderingMode = getTextRenderingMode(context.attributeState)
+        applyContext(context)
         context.pdf.text(transformedText, textX + dx - xOffset, textY + dy, {
           baseline: mapAlignmentBaseline(alignmentBaseline),
           angle: context.transform,


### PR DESCRIPTION
Fixes #80
Applies the current context before rendering a text node